### PR TITLE
Clean input value on change

### DIFF
--- a/src/ngFileReader.js
+++ b/src/ngFileReader.js
@@ -159,6 +159,7 @@
 
           events.onReadered( scope, files );
 
+          $elem.val('');
           $elem.find("input").val('');
           //console.log( 'change' );
           scope.$apply();
@@ -189,7 +190,7 @@
 
               break;
             }
-            
+
           }
 
           return output.toFixed( bit ? bit : 1 ) + " " + ( size_types[index]? size_types[index]:"" );
@@ -200,4 +201,3 @@
   if ( typeof module !== "undefined" ) module.exports = APP_NAME;
 
 })( angular );
-


### PR DESCRIPTION
Picking the same file doesn't trigger onchange event, you might think, well... it didn't change, but in my case I'm using the same inputs in a form where for every select value you have to upload images. If I pick img-1 in option1, I wouldn't be able to pick img-1 in option2 because it doesn't trigger onchange.
